### PR TITLE
2 consolidate control of default routing group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,8 @@ Here's some more advanced use-cases to deliver SMS:
    # send a text to a bunch of receivers in bulk
    bsms.send(['+123456789', '+4985296345', '+44785612458'], 'Hello world! 👋🏻')
 
-   # send a text message with top priority
+   # send a text message with top priority.
+   # Unless priority is requested, the default 'routingGroup' set in the BulkSMS account is used.
    bsms.send('+123456789', 'Hello world! 👋🏻', priority=True)
 
 And here's some inspection use-cases:

--- a/src/bulksms/__init__.py
+++ b/src/bulksms/__init__.py
@@ -14,4 +14,4 @@ Usage:
     bsms.msg_status(res)
 """
 
-from .api import BulkSMS, DEFAULT_ROUTING_GROUP
+from .api import BulkSMS


### PR DESCRIPTION
Do not request any `routingGroup` for a delivery, unless the user requests one -- so the default routing group is exclusively controlled in one place at the BulkSMS account.

Resolves #2 